### PR TITLE
Moved clamav-specific scan result code to clamav adapter.

### DIFF
--- a/lib/ddr/antivirus/adapters/clamav_scanner_adapter.rb
+++ b/lib/ddr/antivirus/adapters/clamav_scanner_adapter.rb
@@ -34,11 +34,25 @@ module Ddr
         class ClamavScanResult < Ddr::Antivirus::ScanResult
 
           def virus_found
-            raw if raw.is_a?(String)
+            raw if has_virus?
+          end
+
+          def has_virus?
+            ![0, 1].include?(raw)
           end
 
           def error?
             raw == 1
+          end
+
+          def status
+            return "FOUND #{virus_found}" if has_virus?
+            return "ERROR" if error?
+            "OK"
+          end
+
+          def to_s
+            "#{file_path}: #{status} (#{version})"
           end
 
           def default_version

--- a/lib/ddr/antivirus/adapters/null_scanner_adapter.rb
+++ b/lib/ddr/antivirus/adapters/null_scanner_adapter.rb
@@ -6,11 +6,8 @@ module Ddr
       #
       class NullScannerAdapter < ScannerAdapter
 
-        RESULT = "File not scanned -- using :null scanner adapter."
-
         def scan(path)
-          Ddr::Antivirus.logger.warn(RESULT)
-          Ddr::Antivirus::ScanResult.new(RESULT, path)
+          Ddr::Antivirus::ScanResult.new("#{path}: NOT SCANNED - using :null scanner adapter.", path)
         end
 
       end

--- a/lib/ddr/antivirus/scan_result.rb
+++ b/lib/ddr/antivirus/scan_result.rb
@@ -23,42 +23,25 @@ module Ddr
       end
 
       # Subclasses may override to provide description of virus found.
-      # Should return nil if no virus found.
       def virus_found; end
 
+      # Subclasses should override
       def has_virus?
         !virus_found.nil?
       end
 
-      def status
-        return status_found if has_virus?
-        return status_error if error?
-        status_ok
+      # Subclasses may override to indicate an error condition (not necessarily an exception).
+      def error?
+        false
       end
 
       def ok?
         !(has_virus? || error?)
       end
 
-      # Subclasses may implement to indicate an error condition (not necessarily an exception).
-      def error?
-        false
-      end
-
-      def status_error
-        "ERROR"
-      end
-
-      def status_ok
-        "OK"
-      end
-
-      def status_found
-        "FOUND #{virus_found}"
-      end
-
+      # Subclasses may override
       def to_s
-        "Virus scan: #{status} - #{file_path} (#{version})"
+        "#{raw} (#{version})"
       end
 
     end

--- a/lib/ddr/antivirus/scanner.rb
+++ b/lib/ddr/antivirus/scanner.rb
@@ -20,7 +20,7 @@ module Ddr
         result = adapter.scan(path)
         raise Ddr::Antivirus::VirusFoundError, result if result.has_virus?
         logger.error("Antivirus scanner error (#{result.version})") if result.error?
-        logger.info(result)
+        logger.info(result.to_s)
         result
       end
 

--- a/spec/shared_examples_for_scan_results.rb
+++ b/spec/shared_examples_for_scan_results.rb
@@ -24,15 +24,9 @@ shared_examples "a successful scan result" do
   it "should be ok" do
     expect(subject).to be_ok
   end
-  it "should have OK status" do
-    expect(subject.status).to eq "OK"
-  end
 end
 
 shared_examples "an error scan result" do
-  it "should have ERROR status" do
-    expect(subject.status).to eq("ERROR")
-  end
   it "should have an error" do
     expect(subject).to be_error
   end
@@ -46,9 +40,6 @@ shared_examples "an error scan result" do
 end
 
 shared_examples "a virus scan result" do
-  it "should have FOUND status" do
-    expect(subject.status).to match(/^FOUND/)
-  end
   it "shoud have a virus" do
     expect(subject.virus_found).not_to be_nil
     expect(subject).to have_virus


### PR DESCRIPTION
Remove redundant log message in null adapter.
