### PR TITLE
Surrounds file path with quotes in clamdscan command.

### DIFF
--- a/lib/ddr/antivirus/adapters/clamd_scanner_adapter.rb
+++ b/lib/ddr/antivirus/adapters/clamd_scanner_adapter.rb
@@ -26,7 +26,7 @@ module Ddr
         private
 
         def command(path)
-          `clamdscan --no-summary #{path}`.strip
+          `clamdscan --no-summary "#{path}"`.strip
         end
 
       end


### PR DESCRIPTION
Fixes #22
This is a quick fix!  The long term solution should escape
special shell characters also.